### PR TITLE
ARCH-1805 - Update increment workflow to produce multiple tags

### DIFF
--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -37,13 +37,22 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          persist-credentials: false
 
       # See https://github.com/im-open/git-version-lite for more details around how to increment
       # major/minor/patch through commit messages
       - name: Increment the version
-        uses: im-open/git-version-lite@v2.1.0
+        uses: im-open/git-version-lite@v2
+        id: version
         with:
-          create-ref: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          default-release-type: major
+
+      - name: Create version tag, create or update major, and minor tags
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git tag ${{ steps.version.outputs.NEXT_VERSION }} ${{ github.sha }}
+          git tag -f ${{ steps.version.outputs.NEXT_MAJOR_VERSION }} ${{ github.sha }}
+          git tag -f ${{ steps.version.outputs.NEXT_MINOR_VERSION }} ${{ github.sha }}
+          git push origin ${{ steps.version.outputs.NEXT_VERSION }}
+          git push origin ${{ steps.version.outputs.NEXT_MAJOR_VERSION }} -f
+          git push origin ${{ steps.version.outputs.NEXT_MINOR_VERSION }} -f

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This action connects to an on-premises hosted windows machine and executes a Pow
 | Parameter                  | Is Required | Description                                                                  |
 | -------------------------- | ----------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------- | ---- | ----- |
 | `script-path`              | true        | The local repository path to the script to be executed on the remote machine |
-| `script-arguments`         | false       | A pipe delimited string, `                                                   | `, that contains the arguments for the script - Example: `arg1 | arg2 | arg3` |
+| `script-arguments`         | false       | A pipe delimited string, `|`, that contains the arguments for the script - Example: `arg1 | arg2 | arg3` |
 | `server`                   | true        | The name of the target server                                                |
 | `service-account-id`       | true        | The service account name                                                     |
 | `service-account-password` | true        | The service account password                                                 |
@@ -78,7 +78,8 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Execute Script
-      uses: 'im-open/remote-windows-machine-script-execution@v2.0.2'
+      # You may also reference the major or major.minor version
+      uses: im-open/remote-windows-machine-script-execution@v2.0.3
       with:
         script-path: './execute-script.ps1'
         script-arguments:  'arg1|arg2|arg3'


### PR DESCRIPTION
# Summary of PR changes

- Updating the increment workflow to be consistent with other builds.  Produce a tag for major, major.minor and major.minor.patch versions.


## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
